### PR TITLE
feat(gemstones): Add logic to identify gemstones

### DIFF
--- a/Gemify/Constants/Gemstones.swift
+++ b/Gemify/Constants/Gemstones.swift
@@ -1,0 +1,25 @@
+//
+//  Gemstones.swift
+//  Gemify
+//
+//  Created by Francisco Mestizo on 30/09/25.
+//
+
+import Foundation
+
+let allGemstones: [Gemstone] = [Gemstone(name: "Diamond", recipe: [.carbon]),
+                                     Gemstone(name: "Amethyst", recipe: [.oxigen, .silicon]),
+                                     Gemstone(name: "Ruby", recipe: [.aluminum, .oxigen]),
+                                     Gemstone(name: "Sapphire", recipe: [.aluminum, .oxigen]),
+                                     Gemstone(name: "Pearl", recipe: [.calcium, .carbon, .oxigen]),
+                                     Gemstone(name: "Opal", recipe: [.hydrogen, .oxigen, .silicon]),
+                                     Gemstone(name: "Peridot", recipe: [.magnesium, .oxigen, .silicon]),
+                                     Gemstone(name: "Alexandrite", recipe: [.aluminum, .beryllium, .oxigen]),
+                                     Gemstone(name: "Emerald", recipe: [.aluminum, .beryllium, .oxigen, .silicon]),
+                                     Gemstone(name: "Aquamarine", recipe: [.aluminum, .beryllium, .oxigen, .silicon]),
+                                     Gemstone(name: "Garnet", recipe: [.aluminum, .magnesium, .oxigen, .silicon]),
+                                     Gemstone(name: "Spinel", recipe: [.aluminum, .magnesium, .oxigen]),
+                                     Gemstone(name: "Topaz", recipe: [.aluminum, .fluorine, .hydrogen, .oxigen, .silicon]),
+                                Gemstone(name: "Turquoise", recipe: [.aluminum, .hydrogen, .oxigen, .phosphorus, .copper]),
+                                     Gemstone(name: "Zircon", recipe: [.oxigen, .silicon, .zirconium]),
+                                     Gemstone(name: "Tourmaline", recipe: [.aluminum, .boron, .fluorine, .hydrogen, .lithium, .oxigen, .silicon, .sodium])]

--- a/Gemify/Utils/Gems.swift
+++ b/Gemify/Utils/Gems.swift
@@ -1,0 +1,29 @@
+//
+//  GemCreator.swift
+//  Gemify
+//
+//  Created by Francisco Mestizo on 30/09/25.
+//
+
+import Foundation
+
+enum Element {
+    case oxigen, aluminum, silicon, hydrogen, magnesium, carbon, beryllium, calcium, fluorine, phosphorus, zirconium, boron, lithium, sodium, copper
+}
+
+struct Gemstone {
+    let name: String
+    let recipe: Set<Element>
+}
+
+func createGem(from elems: [Element]) -> Gemstone? {
+    let inputElementsSet = Set(elems)
+    return allGemstones.first { $0.recipe == inputElementsSet }
+}
+
+func formedGemstones(from elements: [Element]) -> [String] {
+    let inputSet = Set(elements)
+    return allGemstones
+        .filter { $0.recipe.isSubset(of: inputSet) }
+        .map { $0.name }
+}


### PR DESCRIPTION
# GemCreator.swift – Function Overview

## `createGem(from:)`
- Accepts an array of `Element`.
- Converts it into a `Set` and checks for an **exact match** against known gemstone recipes.
- Returns the first matching `Gemstone` if found, otherwise `nil`.
- Useful for determining a **single, precisely defined gem**.

## `formedGemstones(from:)`
- Accepts an array of `Element`.
- Finds all gemstones whose recipes are a **subset** of the provided elements.
- Returns an array of gemstone **names** (`[String]`).
- Useful for discovering **all possible gems** that can be formed from a given pool of elements, even if extra elements are present.