### PR TITLE
feat(gems): Add function to convert 3D models of elements into 3d Gems

### DIFF
--- a/Gemify/ImmersiveView.swift
+++ b/Gemify/ImmersiveView.swift
@@ -22,19 +22,68 @@ struct ImmersiveView: View {
     @State private var hasOpenedMenu = false
 
     var body: some View {
-        RealityView { _ in
-            
+        RealityView { content in
+            let modelsContainer = Entity()
+            modelsContainer.name = "ModelsContainer"
+            content.add(modelsContainer)
         } update: { content in
             guard loaded else { return }
             
             if createGem {
                 convertElementsToGem(in: &content, from: objectsToDelete, create: objectsToAdd)
             }
+            
+            guard let modelsContainer = content.entities.first(where: { $0.name == "ModelsContainer" }) else {
+                return
+            }
+            
+            let currentIds = Set(appModel.droppedModels.map { $0.id })
+            for entity in modelsContainer.children {
+                if let idComponent = entity.components[ModelIDComponent.self],
+                   !currentIds.contains(idComponent.id) {
+                    entity.removeFromParent()
+                }
+            }
+            
+            for model in appModel.droppedModels {
+                if let existingEntity = modelsContainer.children.first(where: { entity in
+                    entity.components[ModelIDComponent.self]?.id == model.id
+                }) {
+                    //existingEntity.position = model.position
+                } else {
+                    Task { @MainActor in
+                        do {
+                            let scene = try await Entity(named: model.modelName, in: realityKitContentBundle)
+                            scene.position = model.position
+                            scene.scale = SIMD3<Float>(repeating: 1.0)
+                            
+                            scene.components.set(GestureComponent())
+                            scene.components.set(InputTargetComponent())
+                            scene.components.set(CollisionComponent(
+                                shapes: [ShapeResource.generateBox(size: [0.1, 0.1, 0.1])],
+                                mode: .default,
+                                filter: CollisionFilter(group: .all, mask: .all)))
+                            
+                            scene.components.set(ModelIDComponent(id: model.id))
+                            
+                            modelsContainer.addChild(scene)
+                        } catch {
+                            print("Error loading \(model.modelName): \(error.localizedDescription)")
+                        }
+                    }
+                }
+            }
         }
         .installGestures()
         .task {
             await preloadEntities()
             loaded = true
+            
+            if !hasOpenedMenu {
+                hasOpenedMenu = true
+                print("🪟 Opening menu window")
+                openWindow(id: "MenuWindow")
+            }
         }
         
         Button("Toggle 3D model") {
@@ -83,59 +132,6 @@ struct ImmersiveView: View {
                 preloaded[name] = entity
             } else {
                 print("❌ Failed to load \(name)")
-            }
-            
-            let modelsContainer = Entity()
-            modelsContainer.name = "ModelsContainer"
-            content.add(modelsContainer)
-        } update: { content in
-            guard let modelsContainer = content.entities.first(where: { $0.name == "ModelsContainer" }) else {
-                return
-            }
-            
-            let currentIds = Set(appModel.droppedModels.map { $0.id })
-            for entity in modelsContainer.children {
-                if let idComponent = entity.components[ModelIDComponent.self],
-                   !currentIds.contains(idComponent.id) {
-                    entity.removeFromParent()
-                }
-            }
-            
-            for model in appModel.droppedModels {
-                if let existingEntity = modelsContainer.children.first(where: { entity in
-                    entity.components[ModelIDComponent.self]?.id == model.id
-                }) {
-                    //existingEntity.position = model.position
-                } else {
-                    Task { @MainActor in
-                        do {
-                            let scene = try await Entity(named: model.modelName, in: realityKitContentBundle)
-                            scene.position = model.position
-                            scene.scale = SIMD3<Float>(repeating: 1.0)
-                            
-                            scene.components.set(GestureComponent())
-                            scene.components.set(InputTargetComponent())
-                            scene.components.set(CollisionComponent(
-                                shapes: [ShapeResource.generateBox(size: [0.1, 0.1, 0.1])],
-                                mode: .default,
-                                filter: CollisionFilter(group: .all, mask: .all)))
-                            
-                            scene.components.set(ModelIDComponent(id: model.id))
-                            
-                            modelsContainer.addChild(scene)
-                        } catch {
-                            print("Error loading \(model.modelName): \(error.localizedDescription)")
-                        }
-                    }
-                }
-            }
-        }
-        .installGestures()
-        .task {
-            if !hasOpenedMenu {
-                hasOpenedMenu = true
-                print("🪟 Opening menu window")
-                openWindow(id: "MenuWindow")
             }
         }
     }


### PR DESCRIPTION
Add the function "convertElementsToGem()" 

Updates the RealityKit scene by removing specified entities and adding new ones.

- Parameters:
  - content: The current RealityViewContent scene to modify.
  - objectsToDelete: An array of entity names that should be removed from the scene.
  - objectsToCreate: An array of entity names that should be added to the scene if not already present.

This function will:
1. Search the scene for entities matching the names in `objectsToDelete` and remove them.
2. For each name in `objectsToCreate`, check if it’s already in the scene:
   - If not, clone the corresponding preloaded entity, assign it a name and position, and add it to the scene.

For the development of this function now all the 3D models are prefetched and they are rendered when needed. This makes better performance for handling the 3D objects. 